### PR TITLE
[FIX] 푸터 CSS 수정, 레이아웃 컨테이너 수정

### DIFF
--- a/src/components/common/footer/Footer.tsx
+++ b/src/components/common/footer/Footer.tsx
@@ -44,7 +44,6 @@ const Wrapper = styled.div<{ isLandingLayout: boolean; }>`
   justify-content: center;
   gap: 2.5rem;
   position: relative;
-  margin-top: 300px;
   scroll-snap-align: ${(props) => props.isLandingLayout && 'end'};
 `;
 
@@ -55,7 +54,7 @@ const TitleText = styled.div`
   font-family: 'Inter';
   font-style: normal;
   font-weight: 900;
-  font-size: 2.1rem;
+  font-size: 1.8rem;
   text-align: center;
 `;
 
@@ -78,6 +77,6 @@ const ButtonWrapper = styled.div`
   display: flex;
   width: 100%;
   justify-content: center;
-  gap: 30px;
-  margin-bottom: 100px;
+  gap: 27px;
+  margin-bottom: 8px;
 `;

--- a/src/components/common/footer/FooterButton.tsx
+++ b/src/components/common/footer/FooterButton.tsx
@@ -17,7 +17,6 @@ const FooterButton = ({ Img, link }: FooterButtonProps) => {
           <ImageWrapper>
             <Image src={Img} width={'40px'} height={'40px'} alt="share" layout="fill" />
           </ImageWrapper>
-          {/* <Img width={'30px'} height={'30px'} viewBox='0 0 50 50' preserveAspectRatio="xMinYMin meet" /> */}
         </Button>
       </a>
     </Link>
@@ -28,25 +27,17 @@ export default FooterButton;
 
 const Button = styled.div`
   background-color: ${Primary.default};
-  width: 74px;
-  height: 74px;
   border-radius: 1.2rem;
   display: inline-flex;
   justify-content: center;
   align-items: center;
   border-radius: 100px;
-  @media (max-width: 1550px) {
-    width: 60px;
-    height: 60px;
-  }
+  width: 40px;
+  height: 40px;
 `;
 
 const ImageWrapper = styled.div`
   position: relative;
-  width: 40px;
-  height: 40px;
-  @media (max-width: 1550px) {
-    width: 33px;
-    height: 33px;
-  }
+  width: 22px;
+  height: 22px;
 `;

--- a/src/components/common/layout/LayoutDefault.tsx
+++ b/src/components/common/layout/LayoutDefault.tsx
@@ -19,7 +19,7 @@ const LayoutDefault = ({ children }: { children: ReactElement; }) => {
 export default LayoutDefault;
 const PageContainer = styled.div`
   background-color: ${BackgroundColor};
-  min-height: calc(100vh - 180.5px);
+  min-height: calc(100vh - 184px);
   width: 100%;
 
   @media (max-width: 1440px) {

--- a/src/components/common/layout/LayoutLogin.tsx
+++ b/src/components/common/layout/LayoutLogin.tsx
@@ -17,16 +17,8 @@ const LayoutLogin = ({ children }: { children: ReactElement; }) => {
 export default LayoutLogin;
 
 const PageContainer = styled.div`
-background-color: ${BackgroundColor};
-min-height: calc(100vh - 270px);
-width: 100%;
-
-/* @media (max-width: 1440px) {
-    padding: 0 250px;
-}
-
-@media (max-width: 1280px) {
-    padding: 0 150px;
-} */
+    background-color: ${BackgroundColor};
+    min-height: calc(100vh - 184px);
+    width: 100%;
     padding: 0 360px;
 `;

--- a/src/components/common/layout/LayoutNoHeight.tsx
+++ b/src/components/common/layout/LayoutNoHeight.tsx
@@ -4,23 +4,27 @@ import Footer from '@common/footer/Footer';
 import styled from 'styled-components';
 import { ReactElement } from 'react';
 
-const LayoutLanding = ({ children }: { children: ReactElement; }) => {
-  return (
-    <>
-      <NavBar />
-      <main>
-        <PageContainer>{children}</PageContainer>
-      </main>
-      <Footer isLandingLayout={true} />
-    </>
-  );
+const LayoutNoHeight = ({ children }: { children: ReactElement; }) => {
+    return (
+        <>
+            <NavBar />
+            <main>
+                <PageContainer>{children}</PageContainer>
+            </main>
+            <Footer isLandingLayout={false} />
+        </>
+    );
 };
 
-export default LayoutLanding;
+export default LayoutNoHeight;
+
 const PageContainer = styled.div`
   background-color: ${BackgroundColor};
   min-height: calc(100vh - 184px);
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 
   @media (max-width: 1440px) {
     padding: 100px 250px 100px 250px;

--- a/src/components/home/video/VideoSection.tsx
+++ b/src/components/home/video/VideoSection.tsx
@@ -15,6 +15,7 @@ export default VideoSection;
 
 const Video = styled.video`
   width: 100%;
+  margin-top:50px;
 `;
 
 const Wrapper = styled.div`

--- a/src/components/home/video/VideoSection.tsx
+++ b/src/components/home/video/VideoSection.tsx
@@ -24,4 +24,5 @@ const Wrapper = styled.div`
   min-height: 70vh;
   height: 100%;
   scroll-snap-align: start;
+  justify-content: center;
 `;

--- a/src/components/login/failed/FailedMessage.tsx
+++ b/src/components/login/failed/FailedMessage.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
-import styled from 'styled-components'
+import styled from 'styled-components';
 import Image from 'next/image';
 
-import alert from '@image/alert.png'
+import alert from '@image/alert.png';
 
 const FailedMessage = () => {
     return (
         <MessageWrapper>
             <div>
-                <Image src={alert} alt='알림' width='20px' height='20px'/>
+                <Image src={alert} alt='알림' width='20px' height='20px' />
                 <StMessageText>알림</StMessageText>
             </div>
             <StMessageText>LIKE LION 계정으로만 로그인이 가능합니다.</StMessageText>
-
         </MessageWrapper>
     );
 };
@@ -43,7 +42,7 @@ div{
 
 }
 
-`
+`;
 
 const StMessageText = styled.div`
 font-family: 'Pretendard';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { useRef } from 'react';
+import { ReactElement, useRef } from 'react';
 
 import VideoSection from '@home/video/VideoSection';
 import PlanSection from '@home/plan/PlanSection';
@@ -10,6 +10,7 @@ import VisionSection from '@home/vision/VisionSection';
 import ScrollBar from '@home/ScrollBar/ScrollBar';
 
 import More from '@image/home_more.svg';
+import LayoutLanding from '@common/layout/LayoutLanding';
 
 function Landing() {
   const ref = useRef(null);
@@ -29,6 +30,9 @@ function Landing() {
     </SectionWrapper>
   );
 }
+Landing.getLayout = function getLayout(page: ReactElement) {
+  return <LayoutLanding>{page}</LayoutLanding>;
+};
 
 export default Landing;
 const SectionWrapper = styled.div`

--- a/src/pages/login/failed.tsx
+++ b/src/pages/login/failed.tsx
@@ -1,8 +1,9 @@
 import React, { ReactElement } from 'react';
 import styled from 'styled-components';
 import FailedMessage from 'src/components/login/failed/FailedMessage';
+import LayoutNoHeight from '@common/layout/LayoutNoHeight';
 
-const Failed = () => {
+const LoginFailed = () => {
     return (
         <Wrapper>
             <FailedMessage />
@@ -10,11 +11,14 @@ const Failed = () => {
     );
 };
 
-export default Failed;
+export default LoginFailed;
+
+LoginFailed.getLayout = function getLayout(page: ReactElement) {
+    return <LayoutNoHeight>{page}</LayoutNoHeight>;
+};
 
 const Wrapper = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 100vh;
 `;


### PR DESCRIPTION
## 🛠️ 한 줄 요약

푸터가 갖고있던 마진 값을 제거했습니다.
LayoutNoHeight (높이 제거 레이아웃) 을 추가했습니다.

## 상세

1. 기존 푸터의 margin bottom 값 제거, 푸터 아이콘 크기 축소, 미디어 쿼리 제거
2. 레이아웃 컨테이너 min height 조절

기존 레이아웃 컴포넌트의 페이지 컨테이너는 min-height 값으로 calc(100vh-푸터의 높이값) 을 가지고 갑니다.
페이지에 컴포넌트가 충분한 경우에는 큰 문제가 되지 않지만, /login/failed 와 같이 페이지에 컴포넌트 높이 차지가 부족한 페이지의 경우
두 가지 문제가 있습니다.
첫번째는 LayoutDefault 페이지 컨테이너에 display: flex 속성과 justify-content: center가 없어 컴포넌트가 차지하는 세로 중앙 정렬이 되지 않으며 푸터가 스크롤 아래쪽으로 내려가게 되어있습니다. 
두번째는 푸터의 아이콘 크기가 미디어 쿼리로 되어있어, height 가 바뀌면서 페이지 컨테이너의 min-height 값이 영향을 받아 푸터가 하단에 붙어있지 않고 살짝 뜨게 됩니다.

첫번째 문제를 위해서 LayoutNoHeight 이라는 레이아웃 컴포넌트를 추가 생성했어요. 컴포넌트 높이 합이 100vh를 넘지 않는 페이지에서 사용하시면 중앙 정렬을 해줍니다. 

두번째 문제는 푸터의 미디어 쿼리를 제거해 height가 항상 고정이도록 수정하였습니다. 마진을 줄 때에는 각 레이아웃의 페이지 컨테이너나, 최하단 컴포넌트에 마진을 주는 것이 좋을 것 같습니다.
현재 푸터의 높이값은 184px로 모든 레이아웃 페이지 컨테이너의 min-height값에 적용해두었습니다. 

그리고 푸터가 전체적으로 사이즈가 큰 느낌이 있어서 줄여주었습니다.

## 📢 같이 상의할 만한 것

1.  이렇게 했을 때, 문제점은 푸터섹션의 크기가 줄어들면서 동길이가 작업해준 랜딩 페이지의 섹션이 딱 맞아떨어지지 않게 되었어요. 그래서 랜딩 페이지 스크롤이 정확하게 내려가지 않습니다. 그리고 푸터까지 스크롤이 내려가지 않게 되었습니다. 이 점 동길님이 보시고 수정해주시면 좋을 것 같슴다
2. 그리고 랜딩 동영상과 내브바 사이의 간격이 너무 좁아서, 이 부분에 여백을 주어 섹션을 조금씩 밀어내면 좋을 것 같아요 !! 