### PR TITLE
[REFACTOR] NavBar Button 개선

### DIFF
--- a/src/components/common/header/HoverButton.tsx
+++ b/src/components/common/header/HoverButton.tsx
@@ -1,0 +1,97 @@
+import { BackgroundColor, Basic, GreyScale, Primary } from '@utils/constant/color';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import Link from 'next/link';
+
+interface IHoverButton {
+    menu: {
+        title: string;
+        routing?: string;
+    }[];
+}
+
+const HoverButton = ({ menu }: IHoverButton) => {
+    const [dropdownVisibility, setDropdownVisibility] = useState(false);
+    const ref = useRef() as React.MutableRefObject<HTMLDivElement>;
+
+
+    const handleMouseOver = useCallback(() => setDropdownVisibility(true), []);
+    const handleMouseOut = useCallback(() => setDropdownVisibility(false), []);
+
+    useEffect(() => {
+        const c = ref.current;
+        if (!c) return;
+        c.addEventListener('mouseover', handleMouseOver);
+        c.addEventListener('mouseout', handleMouseOut);
+
+        return () => {
+            c.removeEventListener('mouseover', handleMouseOver);
+            c.removeEventListener('mouseout', handleMouseOut);
+        };
+
+    }, [ref, handleMouseOut, handleMouseOver]);
+
+    return (
+        <Button onMouseOver={handleMouseOver} onMouseOut={handleMouseOut} ref={ref}>
+            {menu[0].title}
+            {dropdownVisibility &&
+                <DropdownList onMouseOver={handleMouseOver} onMouseOut={handleMouseOut} ref={ref}>
+                    {menu.slice(1).map((m, i) => (
+                        <>
+                            {
+                                m.routing &&
+                                <Link key={i} href={m.routing}>
+                                    <Button className='hover'>{m.title}</Button>
+                                </Link>
+                            }
+                        </>
+                    ))}
+                </DropdownList>
+            }
+        </Button>
+    );
+};
+
+export default HoverButton;
+
+const Button = styled.div`
+  background: none;
+  padding: 1rem 4rem;
+  border: none;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 1.5rem;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+
+  &.hover{
+    border-radius: 5px;
+    font-weight: 500;
+    &:hover{
+        background-color: ${GreyScale.light};
+    }
+  }
+
+`;
+
+
+const DropdownList = styled.div`
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    padding: 0.8rem;
+    width: 100%;
+    top: 3.5rem;
+    z-index: 1;
+    border-radius: 1rem;
+    background-color: ${BackgroundColor};
+    border-radius: 1rem;
+    background-color: ${BackgroundColor};
+    box-shadow: 3px 3px 20px 0px #00000014;
+
+`;

--- a/src/components/common/header/HoverButton.tsx
+++ b/src/components/common/header/HoverButton.tsx
@@ -2,15 +2,14 @@ import { BackgroundColor, Basic, GreyScale, Primary } from '@utils/constant/colo
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import Link from 'next/link';
+import { IHoverButton } from './NavBar';
 
-interface IHoverButton {
-    menu: {
-        title: string;
-        routing?: string;
-    }[];
+interface IHoverButtonProps {
+    hover: IHoverButton['hover'];
+    dropdown: IHoverButton['dropdown'];
 }
 
-const HoverButton = ({ menu }: IHoverButton) => {
+const HoverButton = ({ hover, dropdown }: IHoverButtonProps) => {
     const [dropdownVisibility, setDropdownVisibility] = useState(false);
     const ref = useRef() as React.MutableRefObject<HTMLDivElement>;
 
@@ -33,15 +32,15 @@ const HoverButton = ({ menu }: IHoverButton) => {
 
     return (
         <Button onMouseOver={handleMouseOver} onMouseOut={handleMouseOut} ref={ref}>
-            {menu[0].title}
+            {hover.title}
             {dropdownVisibility &&
                 <DropdownList onMouseOver={handleMouseOver} onMouseOut={handleMouseOut} ref={ref}>
-                    {menu.slice(1).map((m, i) => (
+                    {dropdown.map((d, i) => (
                         <>
                             {
-                                m.routing &&
-                                <Link key={i} href={m.routing}>
-                                    <Button className='hover'>{m.title}</Button>
+                                d.routing &&
+                                <Link key={i} href={d.routing}>
+                                    <Button className='hover'>{d.title}</Button>
                                 </Link>
                             }
                         </>

--- a/src/components/common/header/NavBar.tsx
+++ b/src/components/common/header/NavBar.tsx
@@ -9,10 +9,38 @@ import { useRecoilState } from 'recoil';
 import { accessToken } from '@utils/state';
 import HoverButton from './HoverButton';
 
+export interface IHoverButton {
+  'hover': {
+    title: string;
+  };
+  'dropdown': IMenu[];
+}
+
+interface IMenu {
+  title: string;
+  routing: string;
+}
+
 const NavBar = () => {
   const [tokenState, setTokenState] = useRecoilState(accessToken);
-  const hoverMenu = [{ title: '아카이빙' }, { title: '세션', routing: '/session' }, { title: '추억', routing: '/gallery' }];
 
+  const hover: IHoverButton['hover'] = { title: '아카이빙' };
+  const dropdown: IHoverButton['dropdown'] = [
+    { title: '세션', routing: '/session' },
+    { title: '추억', routing: '/gallery' },
+  ];
+
+  const menuDataSelector = (tokenState: string): IMenu[] => {
+    const resultArray = [
+      { title: '프로젝트', routing: '/project' },
+      { title: tokenState ? 'MY' : 'Log in', routing: tokenState ? '/mypage' : 'login' },
+    ];
+    if (tokenState) {
+      const [project, login] = resultArray;
+      return [project, { title: '출석체크', routing: '/attendance' }, login];
+    }
+    return resultArray;
+  };
 
   return (
     <Wrapper>
@@ -27,10 +55,10 @@ const NavBar = () => {
         </Link>
       </LogoWrapper>
       <ButtonWrapper>
-        <HoverButton menu={hoverMenu} />
-        <NavBarButton title={'프로젝트'} routing={'/project'} />
-        {tokenState && <NavBarButton title='출석체크' routing={'/attendance'} />}
-        <NavBarButton title={tokenState ? 'MY' : 'Log in'} routing={tokenState ? '/mypage' : '/login'} />
+        <HoverButton hover={hover} dropdown={dropdown} />
+        {menuDataSelector(tokenState).map(({ title, routing }, index) => (
+          <NavBarButton key={index} title={title} routing={routing} />
+        ))}
       </ButtonWrapper>
     </Wrapper>
   );

--- a/src/components/common/header/NavBar.tsx
+++ b/src/components/common/header/NavBar.tsx
@@ -2,29 +2,15 @@ import Image from 'next/image';
 import React from 'react';
 import styled from 'styled-components';
 import CAULogo from '@image/cau사자.png';
-import NavBarButton from './NavBarButton';
+import NavBarButton from './NavButton';
 import { BackgroundColor } from '@utils/constant/color';
 import Link from 'next/link';
 import { useRecoilState } from 'recoil';
 import { accessToken } from '@utils/state';
+import HoverButton from './HoverButton';
 
 const NavBar = () => {
   const [tokenState, setTokenState] = useRecoilState(accessToken);
-
-  const NavBarData = [
-    {
-      title: '아카이빙',
-      routing: '/gallery',
-    },
-    {
-      title: '커뮤니티',
-      routing: '/freeboard/list/1',
-    },
-    {
-      title: '출석체크',
-      routing: '/attendance',
-    }
-  ];
 
   return (
     <Wrapper>
@@ -39,13 +25,9 @@ const NavBar = () => {
         </Link>
       </LogoWrapper>
       <ButtonWrapper>
-        {NavBarData.map((navbarButton, index) => (
-          <NavBarButton
-            key={index}
-            title={navbarButton.title}
-            routing={navbarButton.routing}
-          />
-        ))}
+        <HoverButton menu={[{ title: '아카이빙' }, { title: '세션', routing: '/session' }, { title: '추억', routing: '/gallery' }]} />
+        <NavBarButton title={'프로젝트'} routing={'/project'} />
+        {tokenState && <NavBarButton title='출석체크' routing={'/attendance'} />}
         <NavBarButton title={tokenState ? 'MY' : 'Log in'} routing={tokenState ? '/mypage' : '/login'} />
       </ButtonWrapper>
     </Wrapper>
@@ -71,12 +53,13 @@ const Wrapper = styled.div`
   justify-content: space-between;
   background-color: ${BackgroundColor};
   z-index: 9999;
-  /* border-bottom: 1px solid #000000; */
 `;
+
 const LogoImage = styled.div`
 min-width: 50px;
 min-height: 50px;
 `;
+
 const LogoWrapper = styled.div`
   display: flex;
   cursor: pointer;
@@ -94,6 +77,6 @@ const Title = styled.p`
 
 const ButtonWrapper = styled.div`
   display: flex;
-  width: 500px;
+  gap: 20px;
   justify-content: space-between;
 `;

--- a/src/components/common/header/NavBar.tsx
+++ b/src/components/common/header/NavBar.tsx
@@ -11,6 +11,8 @@ import HoverButton from './HoverButton';
 
 const NavBar = () => {
   const [tokenState, setTokenState] = useRecoilState(accessToken);
+  const hoverMenu = [{ title: '아카이빙' }, { title: '세션', routing: '/session' }, { title: '추억', routing: '/gallery' }];
+
 
   return (
     <Wrapper>
@@ -25,7 +27,7 @@ const NavBar = () => {
         </Link>
       </LogoWrapper>
       <ButtonWrapper>
-        <HoverButton menu={[{ title: '아카이빙' }, { title: '세션', routing: '/session' }, { title: '추억', routing: '/gallery' }]} />
+        <HoverButton menu={hoverMenu} />
         <NavBarButton title={'프로젝트'} routing={'/project'} />
         {tokenState && <NavBarButton title='출석체크' routing={'/attendance'} />}
         <NavBarButton title={tokenState ? 'MY' : 'Log in'} routing={tokenState ? '/mypage' : '/login'} />

--- a/src/components/common/header/NavBar.tsx
+++ b/src/components/common/header/NavBar.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import React from 'react';
 import styled from 'styled-components';
 import CAULogo from '@image/cau사자.png';
-import NavBarButton from './NavButton';
+import NavButton from './NavButton';
 import { BackgroundColor } from '@utils/constant/color';
 import Link from 'next/link';
 import { useRecoilState } from 'recoil';
@@ -57,7 +57,7 @@ const NavBar = () => {
       <ButtonWrapper>
         <HoverButton hover={hover} dropdown={dropdown} />
         {menuDataSelector(tokenState).map(({ title, routing }, index) => (
-          <NavBarButton key={index} title={title} routing={routing} />
+          <NavButton key={index} title={title} routing={routing} />
         ))}
       </ButtonWrapper>
     </Wrapper>

--- a/src/components/common/header/NavButton.tsx
+++ b/src/components/common/header/NavButton.tsx
@@ -7,7 +7,7 @@ interface INavBarButton {
   routing: string;
 }
 
-const NavBarButton = ({ title, routing }: INavBarButton) => {
+const NavButton = ({ title, routing }: INavBarButton) => {
   if (title === 'Log in' || title === 'MY')
     return (
       <Link href={routing}>
@@ -22,7 +22,7 @@ const NavBarButton = ({ title, routing }: INavBarButton) => {
   );
 };
 
-export default NavBarButton;
+export default NavButton;
 
 const Button = styled.div`
   background: none;

--- a/src/components/common/header/NavButton.tsx
+++ b/src/components/common/header/NavButton.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import React from 'react';
 import styled from 'styled-components';
+
 interface INavBarButton {
   title: string;
   routing: string;
@@ -25,7 +26,7 @@ export default NavBarButton;
 
 const Button = styled.div`
   background: none;
-  margin: 0 2%;
+  padding: 1rem 4rem;
   border: none;
   font-family: 'Pretendard';
   font-style: normal;
@@ -42,5 +43,6 @@ const LoginButton = styled(Button)`
   border-radius: 52px;
   background-color: #333333;
   color: white;
-  padding: 11px 28px;
+  margin: 0 2rem;
+  padding: 1rem 2rem;
 `;


### PR DESCRIPTION
## 🛠️ 한 줄 요약

NavBar 버튼들 중 hover 시 드롭다운메뉴가 노출되는 HoverButton 버튼 컴포넌트 추가하였습니다.
useRef 와 useCallback, useEffect를 사용해 이벤트를 등록하고, 사이드 이펙트를 방지하기 위해 제거해주었습니다. 

## 상세
### 메뉴 호버시
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/64634970/217853425-269c71fb-c592-4850-9040-4898dbfd952d.png">
<br/>


### 드롭다운 메뉴 호버시
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/64634970/217853500-e6518885-2539-4308-96da-625bbe5b7644.png">


## 💊 바꾼 것
NavBarData로 관리하던 것을 제거하였습니다. 
accessToken 유무에 따라 MY(Log in) 버튼과 출석체크 버튼을 조건부 렌더링 해줍니다.
ButtonWrapper의 width값을 제거했습니다. 메뉴개수에 따라 어색하지 않게 배치되도록 gap으로 변경했습니다.
HoverButton에는 관리할 메뉴 데이터 배열을 props로 받아 첫번째 인덱스에 해당하는 메뉴가 default, 
두번째 인덱스부터는 드롭다운으로 관리할 수 있도록 만들었습니다. 

## ✅ 작업리스트

- [x] 버튼 컴포넌트 분리 (기본 버튼, hover 버튼)
- [x] mouseover, mouseout 이벤트 등록 및 제거
- [x] 기존 NavBarData 제거
- [x] accessToken 유무 판별
