### PR TITLE
[REFACTOR] 아카이빙 관련 API 연결, CSS 통일

### DIFF
--- a/src/apis/gallery.ts
+++ b/src/apis/gallery.ts
@@ -1,25 +1,17 @@
-import { ArchivingArrayType, IGalleryData, IGalleryDetail } from '@@types/request';
+import { ArchivingArrayType, IGalleryData, IGalleryDetail, ResponseData } from '@@types/request';
 import axios from 'axios';
-import galleryBackupData from './backup/gallery.json';
-import galleryDetailBackupData from './backup/galleryDetail.json';
 
 export async function getGalleries() {
-  try {
-    const res = await axios.get<ArchivingArrayType<IGalleryData>>(
-      `https://286eb829-af4d-43ed-b788-0e8e70ae0820.mock.pstmn.io/galleries`,
-    );
-    return res.data;
-  } catch (err) {
-    return new Promise<ArchivingArrayType<IGalleryData>>((resolve) => resolve(galleryBackupData));
-  }
+  const data = await axios.get<ResponseData<ArchivingArrayType<IGalleryData>>>(
+    'https://api.cau-likelion.org/api/gallery',
+  ).then(res => res.data.data);
+  return data;
 }
+
 export async function getGalleryDetail(id: string) {
-  try {
-    const res = await axios.get<IGalleryDetail>(
-      `https://286eb829-af4d-43ed-b788-0e8e70ae0820.mock.pstmn.io/gallery/${id}`,
-    );
-    return res.data;
-  } catch (err) {
-    return new Promise<IGalleryDetail>((resolve) => resolve(galleryDetailBackupData as any));
-  }
+  const data = await axios.get<ResponseData<IGalleryDetail>>(
+    `https://api.cau-likelion.org/api/gallery/${id}`,
+  ).then(res => res.data.data);
+  console.log(data);
+  return data;
 }

--- a/src/apis/project.ts
+++ b/src/apis/project.ts
@@ -1,27 +1,17 @@
-import { ArchivingArrayType, IProjectData, IProjectDetail } from '@@types/request';
+import { ArchivingArrayType, IProjectData, IProjectDetail, ResponseData } from '@@types/request';
 import axios from 'axios';
-import projectBackupData from './backup/project.json';
-import projectDetailBackupData from './backup/projectDetail.json';
 
 export async function getProjects() {
-  try {
-    const res = await axios.get<ArchivingArrayType<IProjectData>>(
-      `https://286eb829-af4d-43ed-b788-0e8e70ae0820.mock.pstmn.io/projects`,
-    );
-    return res.data;
-  } catch (err) {
-    return new Promise<ArchivingArrayType<IProjectData>>((resolve) => resolve(projectBackupData));
-  }
+  const data = await axios.get<ResponseData<ArchivingArrayType<IProjectData>>>(
+    'https://api.cau-likelion.org/project',
+  ).then(res => res.data.data);
+  return data;
 }
 
 export async function getProjectDetail(id: string) {
-  try {
-    const res = await axios.get<IProjectDetail>(
-      `https://286eb829-af4d-43ed-b788-0e8e70ae0820.mock.pstmn.io/project/${id}`,
-      //내맘대로 적은 url임 이런 api없음 바꿔줘야댐
-    );
-    return res.data;
-  } catch (err) {
-    return new Promise<IProjectDetail>((resolve) => resolve(projectDetailBackupData as any));
-  }
+  const data = await axios.get<ResponseData<IProjectDetail>>(
+    `https://api.cau-likelion.org/project/${id}`,
+
+  ).then(res => res.data.data);
+  return data;
 }

--- a/src/apis/session.ts
+++ b/src/apis/session.ts
@@ -1,30 +1,17 @@
-import { ISessionDetail, ArchivingArrayType, ISessionData } from '@@types/request';
+import { ISessionDetail, ArchivingArrayType, ISessionData, ResponseData } from '@@types/request';
 import axios from 'axios';
-import sessionBackupData from './backup/sessionData.json';
-import sessionDetailBackupData from './backup/sessionDetail.json';
 
 export async function getSessionDetail(id: string) {
-    try {
-        const res = await axios.get<ISessionDetail>(
-            `https://286eb829-af4d-43ed-b788-0e8e70ae0820.mock.pstmn.io/session/${id}`,
-        );
+    const data = await axios.get<ResponseData<ISessionDetail>>(
+        `https://api.cau-likelion.org/api/session/${id}`,
+    ).then(res => res.data.data);
 
-        return res.data;
-    } catch (err) {
-        console.log(err);
-        return new Promise<ISessionDetail>((resolve) => resolve(sessionDetailBackupData as any));
-    }
-
+    return data;
 }
 
 export async function getSessions() {
-    try {
-        const res = await axios.get<ArchivingArrayType<ISessionData>>(`https://b3551adf-6020-42dc-b998-c947dbd93919.mock.pstmn.io/session`,
-        );
-
-        return res.data;
-    } catch (err) {
-        console.log(err);
-        return new Promise<ArchivingArrayType<ISessionData>>((resolve) => resolve(sessionBackupData));
-    }
+    const data = await axios.get<ResponseData<ArchivingArrayType<ISessionData>>>(
+        'https://api.cau-likelion.org/api/session',
+    ).then(res => res.data.data);
+    return data;
 }

--- a/src/components/archiving/Archiving.tsx
+++ b/src/components/archiving/Archiving.tsx
@@ -38,7 +38,8 @@ const Archiving = <Type extends ISessionData | IProjectData | IGalleryData>({
             key={index}
             id={data.id}
             link={link}
-            thumbnail={data.thumbnail}
+            // thumbnail={data.thumbnail}
+            thumbnail={'https://cau-likelion.s3.ap-northeast-2.amazonaws.com/project-img/9%E1%84%80%E1%85%B5/Rectangle_336-1.png}'}
             title={data.title}
             description={data.description}
             dev_stack={'dev_stack' in data ? data.dev_stack : undefined}
@@ -55,6 +56,8 @@ const Wrapper = styled.div`
   margin-bottom: 30px;
 `;
 const ArchivingIndex = styled.div`
+  color: #464646;
+
   font-weight: 900;
   font-size: 2.3rem;
   margin-bottom: 20px;

--- a/src/components/archiving/Card.tsx
+++ b/src/components/archiving/Card.tsx
@@ -19,7 +19,7 @@ const Card = ({ id, thumbnail, title, description, dev_stack, category, link }: 
           <CustomImage src={thumbnail} alt="썸네일" layout="fill" objectFit="fill" objectPosition="center" />
         </ImageWrapper>
         <TextWrapper>
-          <Category>{category}</Category>
+          <Category link={link}>{category}</Category>
           <ProjectTitle>{title}</ProjectTitle>
           {description && <ProjectDesc>{description}</ProjectDesc>}
           {dev_stack && <div></div>}
@@ -98,17 +98,16 @@ const TextWrapper = styled.div`
     width: 380px;
   }
 `;
-const Category = styled.div`
+const Category = styled.div<{ link: string; }>`
   border-radius: 25px;
-  border: 1px solid ${GreyScale.default};
-  max-width: 25%;
+  // border: 1px solid ${GreyScale.default};
+  border: ${props => props.link === 'gallery' ? 'none' : '1px solid ${GreyScale.default}'};
   font-family: 'Pretendard';
   font-style: normal;
   font-weight: 500;
   font-size: 1.2rem;
   display: flex;
   padding: 0.3rem 0;
-  justify-content: center;
   align-items: center;
 `;
 

--- a/src/components/archiving/Carousel.tsx
+++ b/src/components/archiving/Carousel.tsx
@@ -5,8 +5,10 @@ import { AnimatePresence, motion, PanInfo } from 'framer-motion';
 import { useInterval } from 'src/hooks/useInterval';
 import useSlider from 'src/hooks/useSlider';
 
-const Carousel = ({ images }: { images: string[] }) => {
-  const [index, direction, increase, decrease, animateVariant] = useSlider<string>(images, 0.1, 1000, false, 'tween');
+const Carousel = ({ images }: { images: string[]; }) => {
+  const testImages = ['https://cau-likelion.s3.ap-northeast-2.amazonaws.com/project-img/9%E1%84%80%E1%85%B5/Rectangle_336-1.png', 'https://cau-likelion.s3.ap-northeast-2.amazonaws.com/project-img/9%E1%84%80%E1%85%B5/Rectangle_336-1.png'];
+  const [index, direction, increase, decrease, animateVariant] = useSlider<string>(testImages, 0.1, 1000, false, 'tween');
+  // const [index, direction, increase, decrease, animateVariant] = useSlider<string>(images, 0.1, 1000, false, 'tween');
   const [timerBool, setTimerBool] = useState(true);
   const [dragStartX, setdragStartX] = useState(0);
   useInterval(increase, 3000, timerBool);
@@ -34,13 +36,15 @@ const Carousel = ({ images }: { images: string[] }) => {
             onDragEnd={handleScroll}
             custom={direction}
           >
-            <CustomImage src={images[index]} alt="img" layout="fill" objectFit="cover" objectPosition="center" />
+            {/* <CustomImage src={images[index]} alt="img" layout="fill" objectFit="cover" objectPosition="center" /> */}
+            <CustomImage src={testImages[index]} alt="img" layout="fill" objectFit="cover" objectPosition="center" />
           </ImageWrapper>
         </AnimatePresence>
       </CarouselWrapper>
 
       <DiamondWrapper>
-        {Array.from({ length: images.length }, (_, i) => i).map((i) => (
+        {/* {Array.from({ length: images.length }, (_, i) => i).map((i) => ( */}
+        {Array.from({ length: testImages.length }, (_, i) => i).map((i) => (
           <Diamond key={i} color={index === i ? '#1a21bd' : '#F0F1FF'} />
         ))}
       </DiamondWrapper>

--- a/src/components/gallery/GalleryListSection.tsx
+++ b/src/components/gallery/GalleryListSection.tsx
@@ -1,19 +1,27 @@
 import { ArchivingArrayType, IGalleryData } from '@@types/request';
 import Archiving from '@archiving/Archiving';
+import { sortArchivingListDesc } from '@utils/index';
 import React from 'react';
 import { useQuery } from 'react-query';
 import { getGalleries } from 'src/apis/gallery';
+import styled from 'styled-components';
 
-const GalleryListSection = ({ staticData }: { staticData: ArchivingArrayType<IGalleryData> }) => {
+const GalleryListSection = ({ staticData }: { staticData: ArchivingArrayType<IGalleryData>; }) => {
   const { data, isLoading } = useQuery<ArchivingArrayType<IGalleryData>>(['galleries'], getGalleries);
 
   return (
-    <>
-      {Object.entries(isLoading ? staticData : (data as ArchivingArrayType<IGalleryData>))!.map(([year, value]) => (
+    <Wrapper>
+      {sortArchivingListDesc(isLoading ? staticData : (data as ArchivingArrayType<IGalleryData>))!.map(([year, value]) => (
         <Archiving archivingType={'gallery'} archivingIndex={year} archivingData={value} key={year} />
       ))}
-    </>
+    </Wrapper>
   );
 };
 
 export default GalleryListSection;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 3rem;
+`;

--- a/src/components/login/border/BorderSection.tsx
+++ b/src/components/login/border/BorderSection.tsx
@@ -49,8 +49,8 @@ const BorderSectionWrapper = styled.div`
     display: flex;
     left: 0;
     right: 0;
-    top: 15rem;
-    height: 70rem;
+    top: 25rem;
+    height: 50rem;
     border-bottom: 4px #1a21bd solid;
     border-bottom-right-radius: 70px;
 
@@ -75,8 +75,8 @@ const BorderSectionWrapper = styled.div`
   span:nth-child(2) {
     left: 0;
     right: 0;
-    top: 15rem;
-    height: 70rem;
+    top: 25rem;
+    height: 50rem;
     width: 100%;
 
     border-right: 4px #1a21bd solid;
@@ -90,7 +90,7 @@ const BorderSectionWrapper = styled.div`
     position: absolute;
     left: 0;
     right: 0;
-    height: 70rem;
+    height: 50rem;
     width: 99%;
     border-right: 20px #ffffff solid;
     border-radius: 70px;
@@ -119,11 +119,11 @@ const BorderSectionWrapper = styled.div`
 
   //border-top
   span:nth-child(3) {
-    left: 50rem;
+    left: 55rem;
     right: 0;
-    top: 15rem;
-    height: 70rem;
-    width: 50%;
+    top: 25rem;
+    height: 50rem;
+    width: 45%;
     border-top: 4px #1a21bd solid;
     border-radius: 70px;
     z-index: 0;
@@ -135,7 +135,7 @@ const BorderSectionWrapper = styled.div`
     left: 0;
     right: 0;
     top: -1rem;
-    height: 70rem;
+    height: 50rem;
     width: 100%;
     border-top: 20px #ffffff solid;
     border-radius: 70px;
@@ -157,17 +157,17 @@ const BorderSectionWrapper = styled.div`
       border-left: 4px #ffffff solid;
     }
     100% {
-      height: 60rem;
+      height: 40rem;
       border-left: 4px #1a21bd solid;
     }
   }
 
   //border-left
   span:nth-child(4) {
-    left: 50rem;
+    left: 55rem;
     right: 0;
-    top: 15rem;
-    height: 60rem;
+    top: 25rem;
+    height: 40rem;
     width: 50%;
     border-top-left-radius: 70px;
     z-index: 5;
@@ -190,9 +190,9 @@ const BorderSectionWrapper = styled.div`
 
   .aniDiamond {
     position: absolute;
-    left: 49.7rem;
+    left: 54.7rem;
     right: 0;
-    top: 75rem;
+    top: 65rem;
     opacity: 0%;
 
     animation-name: diamond;

--- a/src/components/login/contents/component/LeftSection.tsx
+++ b/src/components/login/contents/component/LeftSection.tsx
@@ -28,7 +28,7 @@ const SectionWrapper = styled.div`
   flex-direction: column;
   justify-content: flex-end;
   width: 60rem;
-  height: 50rem;
+  height: 40rem;
   @media (max-width: 1200px) {
     display: none;
   }
@@ -48,6 +48,6 @@ const StTextWrapper = styled.div`
     font-family: 'Inter';
     font-style: normal;
     font-weight: 900;
-    font-size: 8rem;
+    font-size: 7.5rem;
   }
 `;

--- a/src/components/login/contents/component/LoginButton.tsx
+++ b/src/components/login/contents/component/LoginButton.tsx
@@ -16,9 +16,11 @@ const LoginButton = () => {
         <ButtonWrapper>
             <Button className='google' onClick={handleClick}>
                 <Image src={googleLogo} alt='구글' width='38px' height='38px' />
-                <p>구글로 로그인하기</p>
+                <p className='googleText'>구글로 로그인하기</p>
             </Button>
-            <Button className='likelion'>LIKE LION 계정으로 로그인이 가능합니다.</Button>
+            <GreyButton className='likelion'>
+                <p>LIKE LION 계정으로 로그인이 가능합니다.</p>
+            </GreyButton>
         </ButtonWrapper>
     );
 };
@@ -30,41 +32,55 @@ display: flex;
 flex-direction: column;
 justify-content: center;
 align-items: center;
+font-size: 1rem;
 
 .google{
     display: flex;
-    justify-content: space-between;
     align-items: center;
 
-    font-size: 1.7rem;
-    border: 2px solid #858585;
+    border: 1px solid #858585;
     background-color: white;
     margin-bottom: 2rem;
 
 }
 
 .likelion{
-    font-size: 1.4rem;
     color: #858585;
     background-color: #F5F5F5;
     border: none;
 
 }
+
+p{
+    @media(max-width: 900px){
+        font-size:0.8rem;}
+    }
     
 `;
 
 const Button = styled.button`
-width: 360px;
-height: 60px;
-font-family: 'Pretendard';
-font-style: normal;
-font-weight: 500;
+    display: flex;
+    justify-content: space-between;
 
-border-radius: 70px;
+    width: 25rem;
+    height: 5rem;
+    font-family: 'Pretendard';
+    font-style: normal;
+    font-weight: 500;
+    cursor: pointer;
+    border-radius: 70px;
+    z-index: 20;
 
-z-index: 20;
+    .googleText{margin-right: 5rem;}
 
-p{
-    margin-right: 100px;
-}
+
+`;
+
+const GreyButton = styled(Button)`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: default;
+
+    p{text-align: center;}
 `;

--- a/src/components/login/contents/component/RightSection.tsx
+++ b/src/components/login/contents/component/RightSection.tsx
@@ -18,10 +18,17 @@ const RightSection = () => {
 export default RightSection;
 
 const StCustomWrapper = styled(SectionWrapper)`
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  margin-left: 10rem;
+
+
   @media (max-width: 1200px) {
     height: 100%;
     align-items: center;
     justify-content: center;
+    margin: 0rem;
   }
 `;
 
@@ -30,13 +37,23 @@ const StTextWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-bottom: 15rem;
+  margin-top: 5rem;
+
+  @media (max-width: 1200px){
+    margin-bottom: 10rem;
+  }
+
+  p{
+    text-align: center;
+    width: 25rem;
+  }
+ 
 
   .logoTxt {
     font-family: 'Inter';
     font-style: normal;
     font-weight: 900;
-    font-size: 5rem;
+    font-size: 4rem;
     margin: 0;
   }
 
@@ -44,7 +61,7 @@ const StTextWrapper = styled.div`
     font-family: 'Inter';
     font-style: normal;
     font-weight: 500;
-    font-size: 2.1rem;
+    font-size: 1.8rem;
     color: #fb5101;
     margin: 0;
   }

--- a/src/components/project/projects/ProjectsSection.tsx
+++ b/src/components/project/projects/ProjectsSection.tsx
@@ -3,13 +3,14 @@ import Archiving from '@archiving/Archiving';
 import React from 'react';
 import { useQuery } from 'react-query';
 import { getProjects } from 'src/apis/project';
+import { sortArchivingListDesc } from '@utils/index';
 
 const ProjectsSection = ({ staticData }: { staticData: ArchivingArrayType<IProjectData>; }) => {
   const { data, isLoading } = useQuery<ArchivingArrayType<IProjectData>>(['projects'], getProjects);
 
   return (
     <>
-      {Object.entries(isLoading ? staticData : (data as ArchivingArrayType<IProjectData>))!.map(
+      {sortArchivingListDesc(isLoading ? staticData : (data as ArchivingArrayType<IProjectData>))!.map(
         ([generation, value]) => (
           <Archiving archivingType={'project'} archivingIndex={generation} archivingData={value} key={generation} />
         ),

--- a/src/components/session/Arrow.tsx
+++ b/src/components/session/Arrow.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import styled from 'styled-components';
 import Image from 'next/image';
-import arrow from '@image/Vector 16.png'
-import {MdKeyboardArrowLeft, MdKeyboardArrowRight} from 'react-icons/md'
+import arrow from '@image/Vector 16.png';
+import { MdKeyboardArrowLeft, MdKeyboardArrowRight } from 'react-icons/md';
 import { GreyScale } from '@utils/constant/color';
 
 interface ISessionComponent {
-    direction : string;
+    direction: string;
+    length: number;
 }
 
-const Arrow = ({direction}:{direction:string}) => {
+const Arrow = ({ direction, length }: { direction: string, length: number; }) => {
     return (
-        <StArrowWrapper>
-            {direction==='left' ? <MdKeyboardArrowLeft size={30} color={GreyScale.default}/> :
-            <MdKeyboardArrowRight size={30} color={GreyScale.default}/>}
+        <StArrowWrapper length={length}>
+            {direction === 'left' ? <MdKeyboardArrowLeft size={30} color={GreyScale.default} /> :
+                <MdKeyboardArrowRight size={30} color={GreyScale.default} />}
         </StArrowWrapper>
 
     );
@@ -22,6 +23,8 @@ const Arrow = ({direction}:{direction:string}) => {
 export default Arrow;
 
 
-const StArrowWrapper = styled.div`
+const StArrowWrapper = styled.div<{ length: number; }>`
+visibility: ${props => props.length === 0 ? 'hidden' : 'visible'};
+
 padding-left: 2rem;
-`
+`;

--- a/src/components/session/SessionModal.tsx
+++ b/src/components/session/SessionModal.tsx
@@ -1,5 +1,5 @@
-import React,{useState,useEffect} from 'react';
-import styled, {keyframes, css} from 'styled-components';
+import React, { useState, useEffect } from 'react';
+import styled, { keyframes, css } from 'styled-components';
 import Card from '@archiving/Card';
 import { Primary, GreyScale } from '@utils/constant/color';
 import back from '@image/back.png';
@@ -7,65 +7,67 @@ import Image from 'next/image';
 import { ISessionData } from '@@types/request';
 import { MdKeyboardArrowLeft } from 'react-icons/md';
 
-type  ModalProps = {
+type ModalProps = {
     trackName: string,
     trackData: ISessionData[];
     handleClose: () => void,
-    visible:boolean,
+    visible: boolean,
 };
 
 
-const SessionModal:React.FC<ModalProps> = ({trackData, trackName, handleClose, visible}) => {
+const SessionModal: React.FC<ModalProps> = ({ trackData, trackName, handleClose, visible }) => {
     const [isOpen, setIsOpen] = useState(false);
 
     useEffect(() => {
         let timeoutId: NodeJS.Timeout;
         if (visible) {
             setIsOpen(true);
-        } 
+        }
         else {
             timeoutId = setTimeout(() => setIsOpen(false), 500);
         }
-    
+
         return () => {
             if (timeoutId !== undefined) {
-            clearTimeout(timeoutId);
-        }};
+                clearTimeout(timeoutId);
+            }
+        };
     }, [visible]);
-    
+
     return (
         <>
-        {isOpen && 
-        <>
-        <StModalLayer onClick={handleClose} visible={visible}/>
+            {isOpen &&
+                <>
+                    <StModalLayer onClick={handleClose} visible={visible} />
 
-        <StModalWrapper visible={visible}>
-            <ModalHeader>
-                <ButtonWrapper>
-                    <div>
-                        <MdKeyboardArrowLeft size={30} color={GreyScale.default} onClick={handleClose}/>
-                        <a>{trackName}</a>
-                    </div>
-                    <UploadButton>+</UploadButton>
-                </ButtonWrapper>
-            </ModalHeader>
+                    <StModalWrapper visible={visible}>
+                        <ModalHeader>
+                            <ButtonWrapper>
+                                <div>
+                                    <MdKeyboardArrowLeft size={30} color={GreyScale.default} onClick={handleClose} />
+                                    <a>{trackName}</a>
+                                </div>
+                                <UploadButton>+</UploadButton>
+                            </ButtonWrapper>
+                        </ModalHeader>
 
-            <CardWrapper>
-                {trackData.slice(0).reverse().map((data,i)=>{
-                    return(
-                        <Card
-                        key={data.id}
-                        id= {data.id}
-                        link='/session'
-                        thumbnail={data.thumbnail}
-                        title={data.title}
-                        category={`${data.degree}차 세션`} />
-                        )
-                    })}
-            </CardWrapper>
-        </StModalWrapper>
-        </>
-        }
+                        <CardWrapper>
+                            {trackData.slice(0).reverse().map((data, i) => {
+                                return (
+                                    <Card
+                                        key={data.id}
+                                        id={data.id}
+                                        link='/session'
+                                        // thumbnail={data.thumbnail}
+                                        thumbnail={' https://cau-likelion.s3.ap-northeast-2.amazonaws.com/project-img/9%E1%84%80%E1%85%B5/Rectangle_336-1.png'}
+                                        title={data.title}
+                                        category={`${data.degree}차 세션`} />
+                                );
+                            })}
+                        </CardWrapper>
+                    </StModalWrapper>
+                </>
+            }
         </>
     );
 };
@@ -85,12 +87,12 @@ const fadeOut = keyframes`
 const slideIn = keyframes`
     0% { transform: translateY(100%);}
     100% { transform: translateY(0); }
-`
+`;
 
 const slideOut = keyframes`
     0% { transform: translateY(0); }
     100% { transform: translateY(100%);}
-`
+`;
 
 const modalSettings = (visible: boolean) => css`
 visibility: ${visible ? 'visible' : 'hidden'};
@@ -100,7 +102,7 @@ transition: visibility 0.3s ease-out;
 `;
 
 
-const StModalLayer = styled.div<{ visible: boolean }>`
+const StModalLayer = styled.div<{ visible: boolean; }>`
 display: flex;
 justify-content: center;
 
@@ -113,15 +115,15 @@ background: rgba(0, 0, 0, 0.3);
 z-index: 9999;
 overflow: hidden;
 
-visibility: ${(props)=> props.visible ? 'visible' : 'hidden'};
-animation: ${(props)=>props.visible ? fadeIn : fadeOut} 0.5s ease-out;
+visibility: ${(props) => props.visible ? 'visible' : 'hidden'};
+animation: ${(props) => props.visible ? fadeIn : fadeOut} 0.5s ease-out;
 
 @media (max-width:900px){
     display: none;
 }
-`
+`;
 
-const StModalWrapper = styled.div<{ visible: boolean }>`
+const StModalWrapper = styled.div<{ visible: boolean; }>`
 display: flex;
 justify-content: center;
 z-index: 10000;
@@ -174,7 +176,7 @@ ${(props) => modalSettings(props.visible)};
     border-radius: 0px;
 }
 
-`
+`;
 
 
 const ModalHeader = styled.div`
@@ -192,7 +194,7 @@ z-index: 10001;
 background-color: #FFFFFF;
 border-bottom: solid 0.2rem #D7D7D7;
 }
-`
+`;
 
 const ButtonWrapper = styled.div`
 display:flex;
@@ -205,7 +207,7 @@ div{
     align-items: center;
     gap: 20px;
 }
-`
+`;
 
 const CardWrapper = styled.div`
     height: 100%;
@@ -252,4 +254,4 @@ visibility: hidden;
 @media (max-width:900px){
     visibility: visible;
 }
-`
+`;

--- a/src/components/session/SessionSection.tsx
+++ b/src/components/session/SessionSection.tsx
@@ -6,33 +6,33 @@ import Slick from './Slick';
 import { ISessionData } from '@@types/request';
 
 
-type  SessionProps = {
+type SessionProps = {
     trackName: string;
     trackData: ISessionData[];
 };
 
-const SessionSection:React.FC<SessionProps> =({trackName, trackData}) => {
-    
+const SessionSection: React.FC<SessionProps> = ({ trackName, trackData }) => {
+    const length = trackData.length;
+    console.log(length);
+
     return (
         <>
-        <StWrapper>
-            <Track track={trackName} trackData={trackData} />
-
-            <StSlideWrapper>
-                <Arrow direction='left' />
-                <Slick
-                    trackData={trackData}
-                    trackName={trackName}/>
-                <Arrow direction='right' />
-            </StSlideWrapper>
-
-        </StWrapper>
+            <StWrapper>
+                <Track track={trackName} trackData={trackData} />
+                <StSlideWrapper>
+                    <Arrow direction='left' length={length} />
+                    <Slick
+                        trackData={trackData}
+                        trackName={trackName} />
+                    <Arrow direction='right' length={length} />
+                </StSlideWrapper>
+            </StWrapper>
         </>
     );
-}
+};
 export default SessionSection;
 
-const StWrapper= styled.div`
+const StWrapper = styled.div`
 display: flex;
 flex-direction: column;
 align-items: center;
@@ -44,7 +44,7 @@ font-size: 4rem;
 width: 100%;
 
 @media (max-width: 1550px) { font-size: 2.3rem;}
-`
+`;
 
 const StSlideWrapper = styled.div`
     display: flex;

--- a/src/components/session/Slick.tsx
+++ b/src/components/session/Slick.tsx
@@ -6,73 +6,59 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import { ISessionData } from '@@types/request';
 
-type  ModalProps = {
+type ModalProps = {
     trackName: string;
     trackData: ISessionData[];
 };
 
 
-const Slick:React.FC<ModalProps> = ({trackData, trackName}) => {
-    const length = trackData.length;
-    const slidesToShowArr = setSlidesToShow();
+const Slick: React.FC<ModalProps> = ({ trackData, trackName }) => {
 
-    function setSlidesToShow(){
-        let arr=[]
-        let i = 4;
-
-        while(i>0){
-            if(length<i){
-                arr.push(length)
-            }
-            else{
-                arr.push(i)
-            }
-            i--;
-        }
-        return[...arr];
-    }
-
-
-    const settings={
+    const settings = {
         infinite: true,
         speed: 1000,
         swipeToSlide: true,
         touchMove: true,
         variableWidth: true,
 
-        responsive:[
-            {breakpoint:900,
-                settings:{
+        responsive: [
+            {
+                breakpoint: 900,
+                settings: {
                     variableWidth: true,
-            }},
-            {breakpoint:600,
-                settings:{
+                }
+            },
+            {
+                breakpoint: 600,
+                settings: {
                     variableWidth: false,
                     slidesToShow: 1,
                     slidesToScroll: 1,
-            }},
+                }
+            },
         ]
-        }
+    };
 
     return (
         <Wrapper>
             <>
-            <StSlider  {...settings}>
-                {trackData.slice(0).reverse().map((data)=>{
-                    return(
-                        <Card
-                        key={data.id}
-                        id= {data.id}
-                        link='/session'
-                        thumbnail={data.thumbnail}
-                        title={data.title}
-                        category={`${data.degree}차 세션`} />
-                    )
+                <StSlider  {...settings}>
+                    {trackData.slice(0).reverse().map((data) => {
+                        return (
+                            <Card
+                                key={data.id}
+                                id={data.id}
+                                link='/session'
+                                // thumbnail={data.thumbnail}
+                                thumbnail={'https://cau-likelion.s3.ap-northeast-2.amazonaws.com/project-img/9%E1%84%80%E1%85%B5/Rectangle_336-1.png'}
+                                title={data.title}
+                                category={`${data.degree}차 세션`} />
+                        );
                     })}
-            </StSlider>
+                </StSlider>
             </>
         </Wrapper>
-        
+
     );
 };
 
@@ -116,4 +102,4 @@ height: 45rem;
     height: 30rem;
 }
 
-`
+`;

--- a/src/components/session/Track.tsx
+++ b/src/components/session/Track.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { useState } from 'react';
 import SessionModal from './SessionModal';
 import { ISessionData } from '@@types/request';
+import { Primary } from '@utils/constant/color';
 
 type TrackProps = {
     track: string,
@@ -32,7 +33,7 @@ const Track: React.FC<TrackProps> = ({ track, trackData }) => {
     return (
         <>
             <StWrapper>
-                <a>{track}</a>
+                <TrackTitle>{track}</TrackTitle>
                 <StShowAll onClick={handleClick}>전체보기 &gt;</StShowAll>
             </StWrapper>
             <SessionModal
@@ -57,16 +58,16 @@ z-index: 10;
 
 @media (max-width:700px){
     margin: 3rem 0 5rem 0;
-
-    a{
-    font-size: 1.8rem;
-}
-
 }
 
 `;
 
 const StShowAll = styled.div`
-color: #1A21BD;
-font-size: 1.4rem;
+color: ${Primary.default};
+font-size: 1.3rem;
+`;
+
+const TrackTitle = styled.div`
+    font-size: 2.3rem;
+    color: #464646;
 `;

--- a/src/pages/gallery/[gallery_id].tsx
+++ b/src/pages/gallery/[gallery_id].tsx
@@ -11,7 +11,7 @@ import { GetStaticPaths } from 'next';
 import { getGalleryDetail } from 'src/apis/gallery';
 import GalleryDetailSection from '@gallery/GalleryDetailSection';
 
-const GalleryDetail = ({ galleryDetailStaticData }: { galleryDetailStaticData: IGalleryDetail }) => {
+const GalleryDetail = ({ galleryDetailStaticData }: { galleryDetailStaticData: IGalleryDetail; }) => {
   const router = useRouter();
   const { data, isLoading } = useQuery<IGalleryDetail>(['galleryDeatil', router.query.project_id], () =>
     getGalleryDetail(router.query.project_id as string),
@@ -40,7 +40,7 @@ export const getStaticPaths: GetStaticPaths = (async) => {
   };
 };
 
-export async function getStaticProps({ params }: { params: { gallery_id: string } }) {
+export async function getStaticProps({ params }: { params: { gallery_id: string; }; }) {
   const galleryDeatilStaticData = await getGalleryDetail(params.gallery_id);
   return {
     props: {

--- a/src/pages/gallery/index.tsx
+++ b/src/pages/gallery/index.tsx
@@ -7,12 +7,12 @@ import { ReactElement } from 'react';
 import { getGalleries } from 'src/apis/gallery';
 import styled from 'styled-components';
 
-const GalleryList = ({ galleryStaticData }: { galleryStaticData: ArchivingArrayType<IGalleryData> }) => {
+const GalleryList = ({ galleryStaticData }: { galleryStaticData: ArchivingArrayType<IGalleryData>; }) => {
   return (
     <>
       <Header pageName="추억" introduce="멋사와 함께 한 추억" />
       {/* <ButtonWrapper> */}
-        {/* <WriteButton>+</WriteButton> */}
+      {/* <WriteButton>+</WriteButton> */}
       {/* </ButtonWrapper> */}
       <GalleryListSection staticData={galleryStaticData} />
     </>
@@ -33,10 +33,6 @@ export async function getStaticProps() {
   };
 }
 export default GalleryList;
-
-const Wrapper = styled.div`
-  margin-top: 5rem;
-`;
 
 const WriteButton = styled.button`
   border: none;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -47,6 +47,7 @@ const StWrapper = styled.div`
   align-items: center;
   width: 100rem;
   height: 80vh;
+  padding: 0px 360px 0px 360px;
 
   @media (max-width: 1440px) {
     padding: 0px 250px 0px 250px;
@@ -54,11 +55,10 @@ const StWrapper = styled.div`
   @media (max-width: 1280px) {
     padding: 0px 150px 0px 150px;
   }
-  padding: 0px 360px 0px 360px;
   @media (max-width: 1200px) {
     padding: 0px;
     width: 100%;
-    height: 100%;
+    max-height: 100vh;
   }
 `;
 
@@ -68,7 +68,6 @@ const StContentsWrapper = styled.div`
   align-items: center;
   position: relative;
   height: 100rem;
-  padding-top: 10rem;
   width: 100rem;
   
   @media (max-width: 1200px) {

--- a/src/pages/session/index.tsx
+++ b/src/pages/session/index.tsx
@@ -12,12 +12,12 @@ const SessionList = ({ sessionStaticData }: { sessionStaticData: ArchivingArrayT
 
     return (
         <>
-        <Header pageName="세션" introduce="멋사에서 진행한 세션" />
-        {Object.values(isLoading?sessionStaticData:data!).map((data,i)=>{
-            return(
-            <SessionSection key={i} trackName={TRACK_NAME[i]} trackData={data}/>
-            )
-        })}
+            <Header pageName="세션" introduce="멋사에서 진행한 세션" />
+            {Object.values(isLoading ? sessionStaticData : data!).map((data, i) => {
+                return (
+                    <SessionSection key={i} trackName={TRACK_NAME[i]} trackData={data} />
+                );
+            })}
         </>
     );
 };
@@ -34,6 +34,7 @@ export async function getStaticProps({ params }: { params: { track: string; }; }
         },
         revalidate: 86400,
     };
+    console.log(sessionStaticData);
 }
 
 export default SessionList;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { TotalScoreParams, UserScore } from "@@types/request";
+import { ArchivingArrayType, IGalleryData, IProjectData, TotalScoreParams, UserScore } from "@@types/request";
 import { GENERATION_CHECKER, TRACK_INDEX } from "./constant";
 
 export const toDateString = (date?: Date, formatter = "-") => {
@@ -50,4 +50,9 @@ export const getTotalNameObject = (data: any): Record<string, UserScore> => {
         };
     });
     return totalNameObject;
+};
+
+export const sortArchivingListDesc = <T extends IGalleryData | IProjectData>(data: ArchivingArrayType<T>): Array<[string, T[]]> => {
+    const newData = Object.entries(data).sort((year, _) => Number(year));
+    return newData.reverse();
 };


### PR DESCRIPTION
## 🛠️ 한 줄 요약
아카이빙 관련 API 연결 후 목업데이터 제거하였고, 아카이빙 리스트의 css를 한번 정리했어요.

### ✅ 상세
1. 로그인 페이지 상단 네브바 겹침 문제 해결 (전체적으로 크기 줄임)
2. 세션페이지에서 슬라이드 개수 0개 일 때 화살표 hidden으로 설정
3. 갤러리페이지에 Card Category는 border: none, 이 외에 아카이빙 페이지는 border 있게 설정
4. 백 아카이빙 api 완성 될 때까지 thumbnail 이미지 src -> 임시적으로 프론트 S3 url로 적어둠

### 📢 같이 상의할 만한 것 
1. 로그인 왜 안되는데요
6. gif 
7. width 900~1200px 에서 랜딩 겹쳐지는 문제