### PR TITLE
Components/css

### DIFF
--- a/src/components/archiving/Card.tsx
+++ b/src/components/archiving/Card.tsx
@@ -98,15 +98,16 @@ const TextWrapper = styled.div`
 `;
 const Category = styled.div<{ link: string }>`
   border-radius: 25px;
-  // border: 1px solid ${GreyScale.default};
-  border: ${(props) => (props.link === 'gallery' ? 'none' : '1px solid ${GreyScale.default}')};
+  border: ${(props) => (props.link === '/gallery' ? 'none' : `1px solid ${GreyScale.default}`)};
+  display: flex;
   font-family: 'Pretendard';
   font-style: normal;
   font-weight: 500;
   font-size: 1.2rem;
-  display: flex;
   padding: 0.3rem 0;
   align-items: center;
+  justify-content: center;
+  width: 8rem;
 `;
 
 const ProjectTitle = styled.div`

--- a/src/components/session/SessionDetailSection.tsx
+++ b/src/components/session/SessionDetailSection.tsx
@@ -43,15 +43,18 @@ const Wrapper = styled.div`
   justify-content: center;
   gap: 3rem;
 
-  @media (max-width: 900px) {
+  @media (max-width: 900px){
     flex-direction: column;
+    align-items: start;
+    gap: 1rem;
   }
 `;
 
 const LeftWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  margin-top: 5rem;
+  align-items: flex-start;
+  /* margin-top: 5rem; */
 
   @media (max-width: 900px) {
     padding: 2rem;
@@ -64,11 +67,7 @@ const LeftWrapper = styled.div`
 
 const RightWrapper = styled.div`
   flex-basis: 70%;
-  padding: 2rem;
 
-  @media (max-width: 900px) {
-    padding: 0rem;
-  }
 `;
 
 const TitleText = styled.div`
@@ -120,7 +119,6 @@ const DescriptionBox = styled.div`
   font-family: 'Pretendard';
   font-style: normal;
   display: flex;
-  justify-content: center;
   align-items: center;
   word-wrap: break-word;
 `;


### PR DESCRIPTION
## 🛠️ 한 줄 요약

아카이빙 페이지 css 수정

### 🔥 바꾼거
1.  세션 상세페이지 가운데 정렬 및 다른 아카이빙 상세 페이지와 폭 맞춤
2. '/gallery'-> 카드 category에 보더 x, '/session', '/project'-> 카드 category에 보더 o

<img width="376" alt="스크린샷 2023-03-08 오후 12 57 16" src="https://user-images.githubusercontent.com/101720703/223616623-d849196d-c511-45ee-a3b8-546de6963b14.png">
<img width="373" alt="스크린샷 2023-03-08 오후 12 57 31" src="https://user-images.githubusercontent.com/101720703/223616642-4995ec8d-d76d-4aae-a482-349fb6284da5.png">
